### PR TITLE
Only render the "Change Summary" if it is not empty

### DIFF
--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -241,7 +241,7 @@ var planSuccessUnwrappedTmpl = template.Must(template.New("").Parse(
 		"{{ if .HasDiverged }}\n\n:warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}"))
 
 var planSuccessWrappedTmpl = template.Must(template.New("").Parse(
-	"Change Summary: `{{.ChangeSummary}}`\n<details><summary>Show Output</summary>\n\n" +
+	"{{ if .ChangeSummary }}Change Summary: `{{.ChangeSummary}}`\n{{end}}<details><summary>Show Output</summary>\n\n" +
 		"```diff\n" +
 		"{{.TerraformOutput}}\n" +
 		"```\n\n" +


### PR DESCRIPTION
This is a "problem" only when using terraform 0.11 which doesn't output a `Plan: ...`/`No Changes.` line with a summary which without this fix always result in an Atlantis comment with an empty `Change Summary:` 

I testes this by running
```
PATH=$PATH:/nail/opt/terraform-0.12/bin/ make test-coverage
PATH=$PATH:/nail/opt/terraform-0.13/bin/ make test-coverage
```
and for 0.11
```
PATH=$PATH:/nail/opt/terraform-0.11/bin/ make test
```
because e2e tests don't actually work with verraform <0.12 , by design (on upstream master as well)
```
....
--- FAIL: TestGitHubWorkflow (0.04s)
    events_controller_e2e_test.go:721: must have terraform version >= 0.12.0, you have 0.11.14
FAIL
coverage: 57.8% of statements
FAIL    github.com/runatlantis/atlantis/server  0.274s
...
```

I think this makes our changes easier to accept in the upstream repo as well.
