### PR TITLE
feat: implement git clone caching with --reference-if-abl

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -156,6 +156,8 @@ const (
 	TFEHostnameFlag                  = "tfe-hostname"
 	TFELocalExecutionModeFlag        = "tfe-local-execution-mode"
 	TFETokenFlag                     = "tfe-token"
+	GitCacheDirFlag                  = "git-cache-dir"
+	GitCacheRefreshIntervalFlag      = "git-cache-refresh-interval"
 	WriteGitCredsFlag                = "write-git-creds" // nolint: gosec
 	WebhookHttpHeaders               = "webhook-http-headers"
 	WebBasicAuthFlag                 = "web-basic-auth"
@@ -175,6 +177,7 @@ const (
 	DefaultBlockedExtraArgs             = "-chdir,--chdir,-plugin-dir,--plugin-dir"
 	DefaultCheckoutStrategy             = CheckoutStrategyBranch
 	DefaultCheckoutDepth                = 0
+	DefaultGitCacheRefreshInterval      = 60
 	DefaultBitbucketBaseURL             = bitbucketcloud.BaseURL
 	DefaultDataDir                      = "~/.atlantis"
 	DefaultEmojiReaction                = ""
@@ -323,6 +326,12 @@ var stringFlags = map[string]stringFlag{
 	ExecutableName: {
 		description:  "Comment command executable name.",
 		defaultValue: DefaultExecutableName,
+	},
+	GitCacheDirFlag: {
+		description: "Path to directory for storing git mirror clones used as reference repos." +
+			" When set, Atlantis uses git clone --reference-if-able to speed up workspace cloning." +
+			" If empty (default), git caching is disabled.",
+		defaultValue: "",
 	},
 	GHHostnameFlag: {
 		description:  "Hostname of your Github Enterprise installation. If using github.com, no need to set.",
@@ -697,6 +706,10 @@ var boolFlags = map[string]boolFlag{
 	},
 }
 var intFlags = map[string]intFlag{
+	GitCacheRefreshIntervalFlag: {
+		description:  "How often (in seconds) the git cache manager refreshes mirrors. Only used when --git-cache-dir is set.",
+		defaultValue: DefaultGitCacheRefreshInterval,
+	},
 	CheckoutDepthFlag: {
 		description: fmt.Sprintf("Used only if --%s=%s.", CheckoutStrategyFlag, CheckoutStrategyMerge) +
 			" How many commits to include in each of base and feature branches when cloning repository." +

--- a/server/events/git_cache.go
+++ b/server/events/git_cache.go
@@ -1,0 +1,251 @@
+package events
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/runatlantis/atlantis/server/logging"
+)
+
+const (
+	// gcStaleLockTimeout is how old a gc.pid lock file must be before we
+	// consider it stale and remove it. GC takes at most ~30s, so 5 minutes
+	// means the lock is definitely from a killed/crashed process.
+	gcStaleLockTimeout = 5 * time.Minute
+
+	// mirrorCloneTimeout is the maximum time allowed for git clone --mirror
+	// when creating a new mirror. Prevents hanging on network issues while
+	// holding the mutex.
+	mirrorCloneTimeout = 5 * time.Minute
+
+	// fetchTimeout is the maximum time allowed for git fetch --all on a mirror.
+	fetchTimeout = 2 * time.Minute
+
+	// fsckTimeout is the maximum time allowed for git fsck --no-full.
+	fsckTimeout = 2 * time.Minute
+
+	// gcTimeout is the maximum time allowed for git gc --auto.
+	gcTimeout = 5 * time.Minute
+)
+
+// GitCacheManager maintains local git mirror clones to speed up workspace cloning.
+// It runs a background goroutine that periodically fetches updates and checks mirror health.
+type GitCacheManager struct {
+	CacheDir string
+	Interval time.Duration
+	Logger   logging.SimpleLogging
+
+	mu sync.Mutex // protects mirror creation
+}
+
+// Start begins the background refresh loop. It blocks until ctx is cancelled.
+func (g *GitCacheManager) Start(ctx context.Context) {
+	g.Logger.Info("git cache manager started, cache dir: %s, refresh interval: %s", g.CacheDir, g.Interval)
+	g.safeRefreshAll()
+
+	ticker := time.NewTicker(g.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			g.safeRefreshAll()
+		case <-ctx.Done():
+			g.Logger.Info("git cache manager stopped")
+			return
+		}
+	}
+}
+
+func (g *GitCacheManager) safeRefreshAll() {
+	defer func() {
+		if r := recover(); r != nil {
+			g.Logger.Err("git cache manager: recovered from panic: %v", r)
+		}
+	}()
+	g.refreshAll()
+}
+
+// EnsureMirror ensures a mirror clone exists for the given repo.
+// If it doesn't exist, it creates one. Returns the mirror path.
+// This is safe to call concurrently.
+func (g *GitCacheManager) EnsureMirror(logger logging.SimpleLogging, cloneURL string, repoFullName string) string {
+	if g == nil || g.CacheDir == "" {
+		return ""
+	}
+
+	mirrorPath := g.mirrorPath(repoFullName)
+
+	if g.isValidMirror(mirrorPath) {
+		return mirrorPath
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	// Double-check after acquiring lock
+	if g.isValidMirror(mirrorPath) {
+		return mirrorPath
+	}
+
+	logger.Info("creating git mirror for %s at %s", repoFullName, mirrorPath)
+
+	if err := os.MkdirAll(filepath.Dir(mirrorPath), 0700); err != nil {
+		logger.Warn("failed to create mirror parent dir: %v", err)
+		return ""
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), mirrorCloneTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "clone", "--mirror", cloneURL, mirrorPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.Warn("failed to create mirror for %s: %s: %s", repoFullName, err, string(output))
+		os.RemoveAll(mirrorPath)
+		return ""
+	}
+
+	logger.Info("git mirror created for %s", repoFullName)
+	return mirrorPath
+}
+
+func (g *GitCacheManager) mirrorPath(repoFullName string) string {
+	return filepath.Join(g.CacheDir, repoFullName+".git")
+}
+
+func (g *GitCacheManager) isValidMirror(path string) bool {
+	cmd := exec.Command("git", "-C", path, "rev-parse", "--git-dir")
+	return cmd.Run() == nil
+}
+
+func (g *GitCacheManager) refreshAll() {
+	entries, err := g.findMirrors()
+	if err != nil {
+		g.Logger.Warn("git cache refresh: failed to scan cache dir: %v", err)
+		return
+	}
+
+	for _, mirrorPath := range entries {
+		g.refreshMirror(mirrorPath)
+	}
+}
+
+func (g *GitCacheManager) refreshMirror(mirrorPath string) {
+	if !g.isHealthy(mirrorPath) {
+		g.Logger.Warn("git cache: mirror %s is corrupt, removing", mirrorPath)
+		os.RemoveAll(mirrorPath)
+		return
+	}
+
+	fetchCtx, fetchCancel := context.WithTimeout(context.Background(), fetchTimeout)
+	defer fetchCancel()
+
+	cmd := exec.CommandContext(fetchCtx, "git", "-C", mirrorPath, "fetch", "--all")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		g.Logger.Warn("git cache: fetch failed for %s: %s: %s", mirrorPath, err, string(output))
+	}
+
+	// Run gc --auto to prevent pack file and loose object accumulation from
+	// frequent fetches and force pushes. This is a one-shot command (not a
+	// persistent mode) — it checks thresholds, runs gc if needed, and exits.
+	// Must be called every cycle.
+	//
+	// Loose objects: individual object files in objects/XX/ created by single
+	// operations (e.g. a commit amend or cherry-pick). Threshold: >6700.
+	// Pack files: compressed bundles of objects created by fetch/clone. Each
+	// git fetch that receives new objects creates a new small pack file.
+	// These packs are additive (old packs still contain historical objects).
+	// Over time, many small packs accumulate — git must search all pack
+	// indexes to find an object, so more packs = slower lookups. Threshold: >50.
+	//
+	// When triggered, gc combines all packs into one optimized pack with
+	// better delta compression, then removes the old small packs. This
+	// reduces disk usage and speeds up object lookups.
+	//
+	// gc --auto is a no-op (~0.1s) unless thresholds are exceeded, in which
+	// case it runs a full repack (~14-30s for large repos).
+	// If gc becomes slow in the future, tune git's gc.autoPackLimit config
+	// to trigger less often (e.g. git config gc.autoPackLimit 100).
+	g.runGC(mirrorPath)
+}
+
+func (g *GitCacheManager) runGC(mirrorPath string) {
+	lockPath := filepath.Join(mirrorPath, "gc.pid")
+
+	// Remove stale gc lock if older than gcStaleLockTimeout. This handles
+	// the case where Atlantis was killed after gc was terminated but before
+	// we could clean up the lock file.
+	if info, err := os.Stat(lockPath); err == nil {
+		if time.Since(info.ModTime()) > gcStaleLockTimeout {
+			g.Logger.Info("git cache: removing stale gc.pid lock for %s (age: %s)", mirrorPath, time.Since(info.ModTime()))
+			os.Remove(lockPath)
+		}
+	}
+
+	gcCtx, gcCancel := context.WithTimeout(context.Background(), gcTimeout)
+	defer gcCancel()
+
+	gcCmd := exec.CommandContext(gcCtx, "git", "-C", mirrorPath, "gc", "--auto")
+	if gcOutput, gcErr := gcCmd.CombinedOutput(); gcErr != nil {
+		// If gc failed (timeout or error), remove the lock file since we know
+		// the process is dead (CommandContext kills it on timeout).
+		os.Remove(lockPath)
+		g.Logger.Warn("git cache: gc --auto failed for %s: %s: %s", mirrorPath, gcErr, string(gcOutput))
+	}
+}
+
+func (g *GitCacheManager) isHealthy(mirrorPath string) bool {
+	if !g.isValidMirror(mirrorPath) {
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), fsckTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "-C", mirrorPath, "fsck", "--no-full", "--no-progress")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// If fsck timed out, assume healthy — if it's actually corrupt,
+		// the next plan will fail and user retries after goroutine recovers.
+		if ctx.Err() == context.DeadlineExceeded {
+			g.Logger.Warn("git cache: fsck timed out for %s, assuming healthy", mirrorPath)
+			return true
+		}
+		g.Logger.Warn("git cache: fsck failed for %s: %s", mirrorPath, string(output))
+		return false
+	}
+	return true
+}
+
+func (g *GitCacheManager) findMirrors() ([]string, error) {
+	var mirrors []string
+
+	err := filepath.Walk(g.CacheDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(path, ".git") && path != g.CacheDir {
+			if _, err := os.Stat(filepath.Join(path, "HEAD")); err == nil {
+				mirrors = append(mirrors, path)
+				return filepath.SkipDir
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("walking cache dir: %w", err)
+	}
+	return mirrors, nil
+}

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -111,6 +111,9 @@ type FileWorkspace struct {
 	GpgNoSigningEnabled bool
 	// flag indicating if we have to merge with potential new changes upstream (directly after grabbing project lock)
 	CheckForUpstreamChanges bool
+	// GitCacheManager handles local mirror clones for faster workspace cloning.
+	// If nil, git caching is disabled.
+	GitCacheManager *GitCacheManager
 }
 
 func (w *FileWorkspace) CheckoutMergeEnabled() bool {
@@ -684,20 +687,41 @@ func (w *FileWorkspace) forceClone(logger logging.SimpleLogging, c wrappedGitCon
 		return w.cloneNonPRRef(logger, c, headCloneURL)
 	}
 
+	// Resolve mirror path for --reference-if-able (empty string if caching is disabled)
+	mirrorPath := ""
+	if w.GitCacheManager != nil {
+		mirrorPath = w.GitCacheManager.EnsureMirror(logger, baseCloneURL, c.pr.BaseRepo.FullName)
+	}
+
 	// if branch strategy, use depth=1
 	if !w.CheckoutMerge {
-		return w.wrappedGit(logger, c, "clone", "--depth=1", "--branch", c.pr.HeadBranch, "--single-branch", headCloneURL, c.dir)
+		args := []string{"clone"}
+		if mirrorPath != "" {
+			args = append(args, "--reference-if-able", mirrorPath)
+		}
+		args = append(args, "--depth=1", "--branch", c.pr.HeadBranch, "--single-branch", headCloneURL, c.dir)
+		return w.wrappedGit(logger, c, args...)
 	}
 
 	// if merge strategy...
 
 	// if no checkout depth, omit depth arg
 	if w.CheckoutDepth == 0 {
-		if err := w.wrappedGit(logger, c, "clone", "--branch", c.pr.BaseBranch, "--single-branch", baseCloneURL, c.dir); err != nil {
+		args := []string{"clone"}
+		if mirrorPath != "" {
+			args = append(args, "--reference-if-able", mirrorPath)
+		}
+		args = append(args, "--branch", c.pr.BaseBranch, "--single-branch", baseCloneURL, c.dir)
+		if err := w.wrappedGit(logger, c, args...); err != nil {
 			return err
 		}
 	} else {
-		if err := w.wrappedGit(logger, c, "clone", "--depth", fmt.Sprint(w.CheckoutDepth), "--branch", c.pr.BaseBranch, "--single-branch", baseCloneURL, c.dir); err != nil {
+		args := []string{"clone"}
+		if mirrorPath != "" {
+			args = append(args, "--reference-if-able", mirrorPath)
+		}
+		args = append(args, "--depth", fmt.Sprint(w.CheckoutDepth), "--branch", c.pr.BaseBranch, "--single-branch", baseCloneURL, c.dir)
+		if err := w.wrappedGit(logger, c, args...); err != nil {
 			return err
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -544,11 +544,26 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	applyLockingClient = locking.NewApplyClient(database, disableApply, disableGlobalApplyLock)
 	workingDirLocker := events.NewDefaultWorkingDirLocker()
 
+	var gitCacheManager *events.GitCacheManager
+	if userConfig.GitCacheDir != "" {
+		if err := os.MkdirAll(userConfig.GitCacheDir, 0700); err != nil {
+			return nil, fmt.Errorf("creating git cache dir %q: %w", userConfig.GitCacheDir, err)
+		}
+		refreshInterval := time.Duration(userConfig.GitCacheRefreshInterval) * time.Second
+		gitCacheManager = &events.GitCacheManager{
+			CacheDir: userConfig.GitCacheDir,
+			Interval: refreshInterval,
+			Logger:   logger,
+		}
+		go gitCacheManager.Start(context.Background())
+	}
+
 	var workingDir events.WorkingDir = &events.FileWorkspace{
 		DataDir:          userConfig.DataDir,
 		CheckoutMerge:    userConfig.CheckoutStrategy == "merge",
 		CheckoutDepth:    userConfig.CheckoutDepth,
 		GithubAppEnabled: githubAppEnabled,
+		GitCacheManager:  gitCacheManager,
 	}
 
 	scheduledExecutorService := scheduled.NewExecutorService(

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -147,6 +147,8 @@ type UserConfig struct {
 	WriteGitCreds              bool            `mapstructure:"write-git-creds"`
 	WebsocketCheckOrigin       bool            `mapstructure:"websocket-check-origin"`
 	UseTFPluginCache           bool            `mapstructure:"use-tf-plugin-cache"`
+	GitCacheDir                string          `mapstructure:"git-cache-dir"`
+	GitCacheRefreshInterval    int             `mapstructure:"git-cache-refresh-interval"`
 }
 
 // ToAllowCommandNames parse AllowCommands into a slice of CommandName


### PR DESCRIPTION
## Problem

  Atlantis performs a full git clone for every workspace on every plan. For large repositories, this can take 15-20+ seconds per clone. With multiple projects affected by a single change, Atlantis clones the repo once per project
  workspace plus once for the default workspace — multiplying the overhead significantly before any terraform commands even run.

  ## Solution

  Add a `GitCacheManager` that maintains local git mirror clones per repo. Workspace clones use `git clone --reference-if-able <mirror>` to borrow objects from the local cache instead of downloading everything from the network.

  ## Benchmark Results

  Tested against a large terraform monorepo (~500MB+ object store):

  | Operation | Time |
  |-----------|------|
  | Full clone (baseline) | ~19s |
  | Clone with `--reference-if-able` (cached) | **~5s** (~75% faster) |
  | Mirror creation (one-time per repo) | ~18s |
  | Mirror refresh (`git fetch --all`) | ~2s |
  | Clone with missing cache (fallback) | ~19s (graceful, no worse than today) |

  Results will vary by repo size and network latency to git host.

  ## How it works

  **Feature gate:** Entire feature is disabled unless `--git-cache-dir` is set (or `ATLANTIS_GIT_CACHE_DIR` env var). When disabled, behavior is identical to upstream.

  **Plan path (read-only, no locks, fully parallel):**
  if mirror exists:
      git clone --reference-if-able <mirror> <remote> <workspace>
  else (first time):
      git clone --mirror <remote> <cache>       (one-time cost)
      git clone --reference-if-able <mirror> <remote> <workspace>

  **Background goroutine (every `--git-cache-refresh-interval` seconds, default 60):**
  1. Walk cache directory, find all mirrors
  2. For each mirror:
     - Health check: `git rev-parse --git-dir` + `git fsck --no-full`
     - If corrupt → remove mirror (next plan recreates it)
     - If healthy → `git fetch --all` (keep mirror fresh)
     - Run `git gc --auto` (prevent pack accumulation)

  ## Why `--reference-if-able` (not `--reference` or `--dissociate`)

  | Approach | Result |
  |----------|--------|
  | `--reference` (upstream PR #6249) | Hard failure if cache is missing/corrupt |
  | `--reference-if-able --dissociate` | Slower than baseline — `--dissociate` repacks all objects locally, negating speed gains |
  | `--reference-if-able` (this PR) | Fast + graceful fallback to full clone if cache is unavailable |

  `--dissociate` copies all borrowed objects into the workspace after clone, negating the speed benefit. Without it, the workspace keeps an alternates link to the mirror — which is safe because workspaces are short-lived (plan/apply then
  cleanup) and we control the mirror lifecycle.

  ## Concurrency design

  | Operation | Locking | Parallelism |
  |-----------|---------|-------------|
  | `git fetch --all` (goroutine) | None — single goroutine, sequential per mirror | N/A |
  | `git clone --reference-if-able` (plan path) | **No lock** — read-only from mirror | Full parallelism |
  | `EnsureMirror` (first-time creation) | Mutex with double-check | Only blocks concurrent first-time creations |

  The goroutine handles all writes to the mirror. Plans only read. No locks in the hot path = full parallelism for concurrent projects.

  ## How mirror works (`git clone --mirror`)

  Creates a bare repository (no working tree) with all objects and all refs (`+refs/*:refs/*`). When a workspace says `--reference-if-able <mirror>`, git looks in the mirror's `objects/` directory for any objects it needs. Objects found
  locally are used directly (disk I/O); only missing objects are fetched from the network.

  ## Cache corruption handling

  | Corruption type | `--reference-if-able` behavior |
  |---|---|
  | Mirror path doesn't exist | Falls back to full clone ✓ |
  | Not a valid git repo (broken structure) | Falls back to full clone ✓ |
  | Valid structure, objects corrupt inside | **Uses it anyway** — workspace may break ✗ |

  The third case is why the goroutine runs `git fsck --no-full` — it catches internal corruption before plans can reference a bad cache. Once detected, the goroutine removes the mirror, and `--reference-if-able` sees a missing path →
  falls back cleanly.

  **Blast radius of corruption:**
  - Active workspaces (mid-plan/apply) when cache is corrupted → broken, plan fails
  - Future workspaces → unaffected, `--reference-if-able` falls back to full clone
  - Recovery → automatic: goroutine detects + removes, next plan recreates

  ## Self-healing and timeouts

  All operations have timeouts to prevent the goroutine from hanging:

  | Operation | Timeout | On timeout |
  |-----------|---------|-----------|
  | `git clone --mirror` (EnsureMirror) | 5 min | Kills clone, removes partial dir, releases mutex, plan falls back to full clone |
  | `git fetch --all` | 2 min | Kills fetch, logs warning, mirror stays intact (stale but usable) |
  | `git fsck --no-full` | 2 min | Kills fsck, assumes healthy (if actually corrupt, next plan fails, user retries) |
  | `git gc --auto` | 5 min | Kills gc, removes stale lock file, logs warning, retries next cycle |

  **Panic recovery:** `safeRefreshAll()` wraps the refresh loop with `recover()` — if anything panics, the goroutine logs the error and continues on the next tick. Never crashes the process.

  **GC stale lock handling:** `gc.pid` lock files are checked before each gc run. If older than 5 minutes (gc never takes that long), considered stale and removed. Also removed immediately after any gc failure/timeout. Handles the case
  where the process was killed between gc termination and lock cleanup.

  ## GC strategy (`git gc --auto`)

  Runs after each fetch. `gc --auto` is a one-shot command (not a persistent mode) that:
  - Checks thresholds: >6700 loose objects OR >50 pack files
  - If below thresholds: exits immediately (~0.1s, no-op)
  - If exceeded: runs full repack, combines all packs into one optimized pack

  Each `git fetch` that receives new objects creates a new pack file. Over time, pack count reaches 50, triggering a repack. This keeps object lookups fast and disk usage bounded.

  If gc becomes slow in the future (repo growth over years), tune `gc.autoPackLimit` config to trigger less often.

  ## `updateToRef` path (Update Branch / new push)

  When a PR gets a new commit (Update Branch, push), Atlantis uses `updateToRef()` — it does `git fetch --all` + `git reset --hard` + merge on the existing workspace. No new clone, no mirror involved. This path is already fast and our
  changes don't affect it.

  ## Disk considerations

  - Mirror size ≈ repo object store size
  - If using a persistent volume, the mirror survives container restarts and redeployments
  - Only lost when the underlying storage is replaced — first plan after that pays one-time mirror creation cost
  - `gc --auto` prevents unbounded growth from pack accumulation

  ## Configuration

  | Flag | Env var | Default | Description |
  |------|---------|---------|-------------|
  | `--git-cache-dir` | `ATLANTIS_GIT_CACHE_DIR` | `""` (disabled) | Path for mirror clones. Empty = feature off. |
  | `--git-cache-refresh-interval` | `ATLANTIS_GIT_CACHE_REFRESH_INTERVAL` | `60` | Seconds between refresh cycles |

  ## Files changed

  | File | Change |
  |------|--------|
  | `cmd/server.go` | New flags: `--git-cache-dir`, `--git-cache-refresh-interval` |
  | `server/user_config.go` | New config fields |
  | `server/server.go` | Create cache dir, start goroutine, pass manager to FileWorkspace |
  | `server/events/working_dir.go` | Add `GitCacheManager` field, modify `forceClone()` to use `--reference-if-able` |
  | `server/events/git_cache.go` | **New** — GitCacheManager with background refresh, health check, gc, timeouts, panic recovery |

  ## Testing

  Validated on a test instance:
  - Mirror creation on first plan ✓
  - Subsequent plans reuse mirror (no re-creation) ✓
  - `--reference-if-able` in all clone commands ✓
  - Alternates files point to cache ✓
  - Background goroutine running + refreshing ✓
  - Mirror recreation after manual deletion ✓
  - Re-plan same commit (fast path, no clone) ✓
  - Update Branch (updateToRef path, no clone) ✓
  - Plan + apply succeed end-to-end ✓

  ## Related

  - Upstream PR #6249: https://github.com/runatlantis/atlantis/pull/6249
  - Upstream issue #5073: https://github.com/runatlantis/atlantis/issues/5073